### PR TITLE
add vcf2maf recipe

### DIFF
--- a/vcf2maf/build.sh
+++ b/vcf2maf/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mkdir -p ${PREFIX}/bin
+chmod +x *.pl && cp *.pl $PREFIX/bin

--- a/vcf2maf/meta.yaml
+++ b/vcf2maf/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "1.6.21.20230511" %}
+{% set sha256 = "76e203b8b76389e78097231b0feb9909051a2238294ae21b403606c9fe0a3011" %}
+
+package:
+  name: vcf2maf
+  version: '{{version}}'
+
+build:
+  noarch: generic
+  number: 0
+
+source:
+  url: https://github.com/umccr/vcf2maf/archive/v{{ version }}.tar.gz
+  sha256: '{{ sha256 }}'
+
+requirements:
+  run:
+    - perl
+    - samtools
+    - htslib
+
+test:
+  commands:
+    - vcf2maf.pl --help
+
+about:
+  home: https://github.com/mskcc/vcf2maf
+  license: Apache-2.0
+  summary: Convert a VCF into a MAF where each variant is annotated to only one of
+    all possible gene isoforms
+
+  license_family: Apache
+extra:
+  notes: |-
+    This package installs only vcf2maf and does not integrate with the variant-effect-predictor (VEP). To
+    do so, please follow the instructions at https://github.com/mskcc/vcf2maf/blob/master/README.md.


### PR DESCRIPTION
Currently building locally, is based on our fork at https://github.com/umccr/vcf2maf/releases/tag/v1.6.21.20230511


--- Done, uploaded at https://anaconda.org/umccr/vcf2maf